### PR TITLE
Do not add an empty default block below content by default, or when changing block formatting

### DIFF
--- a/build/squire-raw.js
+++ b/build/squire-raw.js
@@ -759,7 +759,17 @@ var extractContentsOfRange = function ( range, common ) {
     range.setStart( startContainer, startOffset );
     range.collapse( true );
 
-    fixCursor( common );
+    // Socrata Edit:
+    // When there is a single block-level element in the editor and it's format is
+    // modified (Ex: changing a paragraph to a blockquote)
+    // - It is removed
+    // - This function is run
+    // - The newly formatted block is added
+    // This leads to an empty node being inserted by fixCursor while the body is
+    // empty. Instead, only run fixCursor if there are children in `common`
+    if ( common.childElementCount > 0 ) {
+        fixCursor( common );
+    }
 
     return frag;
 };
@@ -3389,8 +3399,12 @@ var decreaseListLevel = function ( frag ) {
 proto._ensureBottomLine = function () {
     var body = this._body,
         last = body.lastElementChild;
-    if ( !last ||
-            last.nodeName !== this._config.blockTag || !isBlock( last ) ) {
+
+    // Socrata Edit:
+    // This used to insert an extra block unless the last element was the same
+    // as the default block. Now it only adds if there is no block level last
+    // element.
+    if ( !last || !isBlock( last ) ) {
         body.appendChild( this.createDefaultBlock() );
     }
 };


### PR DESCRIPTION
[X] Fix empty-div behavior

Left todo:
[ ] Discuss whether I should reset this fork to the last release (right now it's forked from master)
[ ] Minify my updates into the build version (Do we have a preferred minifiier/uglifier?)
