### PR TITLE
CHART-200: Preserve carriage returns;

### DIFF
--- a/source/Clean.js
+++ b/source/Clean.js
@@ -98,6 +98,7 @@ var stylesRewriters = {
 
         return newTreeBottom || span;
     },
+    P: replaceWithTag( 'DIV' ),
     STRONG: replaceWithTag( 'B' ),
     EM: replaceWithTag( 'I' ),
     STRIKE: replaceWithTag( 'S' ),


### PR DESCRIPTION
This doesn't work with Google Docs. Anything that uses semantic `<p>`'s or `<div>`'s works like a charm.
